### PR TITLE
Fix _ref count

### DIFF
--- a/onnx_connx/proto.py
+++ b/onnx_connx/proto.py
@@ -160,19 +160,6 @@ class ConnxGraphProto(ConnxObject):
                 value_info.sparse_initializer = sparse_initializer
                 self.value_info.append(value_info)
 
-        # Make value_info reflects to input
-        for input in proto.input:
-            if input.name == '':
-                continue
-
-            value_info = self.get_value_info(input.name)
-
-            if value_info is None:
-                value_info = ConnxValueInfoProto(input, self)
-                self.value_info.append(value_info)
-
-            self.input.append(value_info)
-
         # Make value_info reflects to output
         for output in proto.output:
             if output.name == '':
@@ -217,6 +204,24 @@ class ConnxGraphProto(ConnxObject):
                 id += 1
 
         self.node = [ConnxNodeProto(proto, self) for proto in proto.node]
+
+        # Make value_info reflects to input
+        for input in proto.input:
+            if input.name == '':
+                continue
+
+            value_info = self.get_value_info(input.name)
+
+            if value_info is None:
+                value_info = ConnxValueInfoProto(input, self)
+                self.value_info.append(value_info)
+
+            ref_count = self.get_ref_count(input.name)
+            if ref_count > 1:
+                node = self.make_ref_count(input.name, None, ref_count)
+                self.node.insert(0, node)
+
+            self.input.append(value_info)
 
         # Internal operators
         for initializer in self.initializer:

--- a/onnx_connx/proto.py
+++ b/onnx_connx/proto.py
@@ -319,10 +319,10 @@ class ConnxGraphProto(ConnxObject):
 
         for i in range(idx, len(self.node)):
             if name in self.node[i].proto.input:
-                count += 1
+                count += list(self.node[i].proto.input).count(name)
 
         if name in self.proto.output:
-            count += 1
+            count += self.proto.output.count(name)
 
         return count
 


### PR DESCRIPTION
## Create `_ref` for input nodes
It is needed for input nodes too when some nodes are referencing input twice or more

## Correctly count reference count if multiple used on a single node
If something like this: `Concat 1 5 1 672 671 13 13 12 13 4 axis 2 0`
ref count for tensor 13 should counted as 3. not 1