### PR TITLE
Fix and upgrade bin/test

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -22,11 +22,7 @@ else
     echo "VIRTUAL_ENV is not empty, use existing one"
 fi
 
-pip install --upgrade pip pytest tabulate
-if [ "$ONNX_VERSION" = "latest" ]; then
-    pip install -U onnx
-else
-    pip install -U onnx=="${ONNX_VERSION}"
-fi
+[[ "$ONNX_VERSION" = "latest" ]] && ONNX_VERSION='' || ONNX_VERSION="==${ONNX_VERSION}"
+pip install --upgrade pip pytest tabulate "onnx${ONNX_VERSION}"
 
 exec pytest "$@"

--- a/bin/test
+++ b/bin/test
@@ -10,12 +10,23 @@ fi
 ONNX_VERSION=$1
 shift
 
-VENV_DIR="venv-onnx-${ONNX_VERSION}"
-if [ ! -d "$VENV_DIR" ]; then
-    python3 -m venv "$VENV_DIR"
+# Check VIRTUAL_ENV env is empty
+if [ -z "$VIRTUAL_ENV" ]; then
+    VENV_DIR="venv-onnx-${ONNX_VERSION}"
+    if [ ! -d "$VENV_DIR" ]; then
+        python3 -m venv "$VENV_DIR"
+    fi
+
+    source "$VENV_DIR/bin/activate"
+else
+    echo "VIRTUAL_ENV is not empty, use existing one"
 fi
 
-source "$VENV_DIR/bin/activate"
-pip install --upgrade pip pytest tabulate onnx=="$ONNX_VERSION"
+pip install --upgrade pip pytest tabulate
+if [ "$ONNX_VERSION" = "latest" ]; then
+    pip install -U onnx
+else
+    pip install -U onnx=="${ONNX_VERSION}"
+fi
 
 exec pytest "$@"

--- a/bin/test
+++ b/bin/test
@@ -1,18 +1,21 @@
 #!/bin/bash
 
+set -eo pipefail
+
 if [ $# -lt 1 ]; then
     echo "Usage: $0 [onnx version in 1.10.2 format] [[other pytest options]]"
-    exit 0
+    exit 1
 fi
 
-VENV_DIR="venv-onnx-$1"
-if [ ! -d $VENV_DIR ]; then
-    python3 -m venv $VENV_DIR
+ONNX_VERSION=$1
+shift
+
+VENV_DIR="venv-onnx-${ONNX_VERSION}"
+if [ ! -d "$VENV_DIR" ]; then
+    python3 -m venv "$VENV_DIR"
 fi
 
-source $VENV_DIR/bin/activate
-pip install --upgrade pip pytest tabulate onnx==$1
+source "$VENV_DIR/bin/activate"
+pip install --upgrade pip pytest tabulate onnx=="$ONNX_VERSION"
 
-pytest "${@:2}"
-
-deactivate
+exec pytest "$@"


### PR DESCRIPTION
* Return non-zero if error
* Shellcheck lint
* Exec pytest to reduce resource usage and natively use return code of pytest
* Use activated venv if there are
* Support "latest" version

This will used by tsnlab/connx#60 later