### PR TITLE
Use flake8-builtins, flake8-import-order

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         python-version: 3.8
     - name: Install flake8
-      run: pip install flake8 flake8-builtins
+      run: pip install flake8 flake8-builtins flake8-import-order
     - name: Check python lint
       run: flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@master
-    - name: Install ubuntu packages to lint
-      run: sudo apt-get install flake8
+    - name: Setup python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    - name: Install flake8
+      run: pip install flake8 flake8-builtins
     - name: Check python lint
       run: flake8


### PR DESCRIPTION
## flake8-builtins
To avoid overwriting python builtins

This kind of code are prohibited for safety:

```python

def some_function(usernames):
  list = usernames[1:]
  return list
```

## flake8-import-order
`import-order-style=edited` is specified on .flake8 config but not tested because flake8-import-order is not installed on CI